### PR TITLE
Remove Python and NodeJS from base install

### DIFF
--- a/images/centos7.Dockerfile
+++ b/images/centos7.Dockerfile
@@ -11,8 +11,6 @@ RUN yum update -y \
     libicu \
     libyaml-devel \
     lttng-ust \
-    nodejs \
-    npm \
     openssl-libs \
     rpm-build \
     sudo \
@@ -45,7 +43,7 @@ COPY software/kubectl.sh kubectl.sh
 RUN bash kubectl.sh && rm kubectl.sh
 
 ARG TARGETPLATFORM=linux/amd64
-ARG RUNNER_VERSION=2.281.1
+ARG RUNNER_VERSION=2.282.0
 ARG DEBUG=false
 
 RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)

--- a/images/centos8.Dockerfile
+++ b/images/centos8.Dockerfile
@@ -46,7 +46,7 @@ COPY software/kubectl.sh kubectl.sh
 RUN bash kubectl.sh && rm kubectl.sh
  
 ARG TARGETPLATFORM=linux/amd64
-ARG RUNNER_VERSION=2.281.1
+ARG RUNNER_VERSION=2.282.0
 ARG DEBUG=false
 
 RUN test -n "$TARGETPLATFORM" || (echo "TARGETPLATFORM must be set" && false)

--- a/images/debian-bullseye.Dockerfile
+++ b/images/debian-bullseye.Dockerfile
@@ -38,16 +38,12 @@ RUN apt-get update \
     musl-dev \
     nasm \
     netcat \
-    nodejs \
-    npm \
     openssh-client \
     openssl \
     optipng \
     parallel \
     pkg-config \
     pngquant \
-    python3 \
-    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -83,7 +79,7 @@ COPY software/kubectl.sh kubectl.sh
 RUN bash kubectl.sh && rm kubectl.sh
 
 ARG TARGETPLATFORM=linux/amd64
-ARG RUNNER_VERSION=2.281.1
+ARG RUNNER_VERSION=2.282.0
 ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=20.10.8
 ARG COMPOSE_VERSION=1.29.2

--- a/images/debian-buster.Dockerfile
+++ b/images/debian-buster.Dockerfile
@@ -38,16 +38,12 @@ RUN apt-get update \
     musl-dev \
     nasm \
     netcat \
-    nodejs \
-    npm \
     openssh-client \
     openssl \
     optipng \
     parallel \
     pkg-config \
     pngquant \
-    python3 \
-    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -83,7 +79,7 @@ COPY software/kubectl.sh kubectl.sh
 RUN bash kubectl.sh && rm kubectl.sh
 
 ARG TARGETPLATFORM=linux/amd64
-ARG RUNNER_VERSION=2.281.1
+ARG RUNNER_VERSION=2.282.0
 ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=20.10.8
 ARG COMPOSE_VERSION=1.29.2

--- a/images/ubuntu-focal.Dockerfile
+++ b/images/ubuntu-focal.Dockerfile
@@ -27,14 +27,10 @@ RUN apt-get update \
     locales \
     lsb-release \
     netcat \
-    nodejs \
-    npm \
     openssh-client \
     openssl \
     parallel \
     pkg-config \
-    python3 \
-    python3-pip \
     rsync \
     shellcheck \
     sudo \
@@ -82,7 +78,7 @@ RUN apt-get autoclean && apt-get autoremove
 
 # Runner agent and Docker configs
 ARG TARGETPLATFORM=linux/amd64
-ARG RUNNER_VERSION=2.281.1
+ARG RUNNER_VERSION=2.282.0
 ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=20.10.8
 ARG COMPOSE_VERSION=1.29.2


### PR DESCRIPTION
I'm working on paring down the amount of software installed in the base images to both improve performance and provide a better experience. Overall, I'm looking to remove things that you should be using an Action to install, such as npm/nodejs, python, etc.

For these, you should use the following in your workflow:
- github.com/actions/setup-node
- github.com/actions/setup-python

The reasoning behind preferring using the setup Actions provided by GitHub is that it'll allow you to specify the version(s) you want to use and provide a much more consistent experience than using the packages provided by each distro installed at build.