### PR TITLE
change startup.sh so docker consistently starts

### DIFF
--- a/images/startup.sh
+++ b/images/startup.sh
@@ -2,7 +2,7 @@
 source /opt/bash-utils/logger.sh
 
 function wait_for_process () {
-    local max_time_wait=10
+    local max_time_wait=20
     local process_name="$1"
     local waited_sec=0
     while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
@@ -12,7 +12,7 @@ function wait_for_process () {
         ((waited_sec=waited_sec+1))
         if ((waited_sec >= max_time_wait)); then
             {
-              sudo $process &
+              sudo "$process_name" &
             } || {
               return 1
             }
@@ -28,6 +28,7 @@ INFO "Waiting for processes to be running"
 processes=(dockerd)
 
 for process in "${processes[@]}"; do
+    sleep 10
     wait_for_process "$process"
     if [ $? -ne 0 ]; then
         ERROR "$process is not running after max time"


### PR DESCRIPTION
We're finding that Docker isn't consistently starting on time in the pods, so jobs that grab a pod _right_ after it joins the runner pool are failing not being able to connect to a Docker socket.  This is particularly common in jobs that have a bunch of build matrix steps and try to grab more pods than _immediately_ available.  Here's a sample log

```
Download action repository 'securego/gosec@master' (SHA:79c8b792631af830561b99334d33936414f43d89)
##[group]Pull down action image 'securego/gosec'
##[command]/usr/local/bin/docker pull securego/gosec
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Using default tag: latest
##[warning]Docker pull failed with exit code 1, back off 5.595 seconds before retry.
##[command]/usr/local/bin/docker pull securego/gosec
Using default tag: latest
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
##[warning]Docker pull failed with exit code 1, back off 9.254 seconds before retry.
##[command]/usr/local/bin/docker pull securego/gosec
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Using default tag: latest
##[endgroup]
##[error]Docker pull failed with exit code 1
```

This fix both adds a startup delay and allows it a bit longer before failing, which seems to have addressed the problem in a reasonably straightforward manner. :)